### PR TITLE
Remove parenthesis from song title if specified in "Windows Now Playing" mode.

### DIFF
--- a/osc-chat-tools.py
+++ b/osc-chat-tools.py
@@ -2248,6 +2248,8 @@ if __name__ == "__main__":
                         windowAccess.write_event_value('mediaManagerError', e)
                     except:
                       pass
+              if removeParenthesis:
+                title = re.sub(r' ?\([^)]*\)', '', title)
               if mediaPlaying or (not showPaused):
                 songInfo = songDisplay.format_map(defaultdict(str, artist=artist,title=title,album_title=album_title, album_artist=album_artist))
               else:


### PR DESCRIPTION
Added logic to strip parenthesis and their contents from the song title when the removeParenthesis flag is set in "Windows Now Playing" mode. This helps display cleaner song titles in the UI in all audio source info modes.