### PR TITLE
Add multi-vendor GPU support and UI options (Solves #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ OCT Is a standalone program used for interacting with Vrchat's OSC to send chat 
    - winsdk
    - websocket-client
    - pyperclip
+   - requests
+   - flask
    - pynvml
+   - wmi *(Windows — required for AMD/Intel GPU support)*
    - tendo
+   - pyamdgpuinfo *(Linux only — required for AMD GPU support on Linux)*
  - In a command prompt window in the folder the `osc-chat-tools.py` is located in:
  - `pip install PyInstaller`
  - `python -m PyInstaller -wF --icon=oscicon.ico --clean osc-chat-tools.py`

--- a/build.bat
+++ b/build.bat
@@ -9,5 +9,10 @@ pip install winsdk
 pip install websocket-client
 pip install PyInstaller
 pip install pyperclip
+pip install requests
+pip install flask
 pip install pynvml
+pip install wmi
+REM Linux AMD GPU support only (won't build on Windows):
+REM pip install pyamdgpuinfo
 python -m PyInstaller -wF --icon=oscicon.ico --clean osc-chat-tools.py


### PR DESCRIPTION
# Multi-GPU Selection Support (Solves #18)

## Summary

This commit adds multi-GPU detection and selection support to OCT. Previously, GPU usage was always read from a single hardcoded GPU, meaning users with multiple GPUs (e.g. integrated + discrete, or dual-GPU setups) would be unable to select which GPU was queried. 
You can now pick exactly which GPU to display, or show the average across all of them.

## What Was Wrong (Before)

The old GPU implementation used a simple ``GPUtil`` call with no GPU selection (GPUtil was not imported that left me confused) and a simple ``pynvml`` implementation was used too:

```py
def gpu(data=0):
    try:
        nvmlInit()
        handle = nvmlDeviceGetHandleByIndex(0)
        info = nvmlDeviceGetUtilizationRates(handle)
        #print(info)
        gpu_percent = info.gpu
        vram_percent = info.memory
        nvmlShutdown()
    except:
        gpu_percent = "0"
        vram_percent = "0"
    #gpu_percent = str(round((GPUtil.getGPUs()[0].load*100), 1))
    #gpu_percent = "0"
    gpuDat = gpuDisplay.format_map(defaultdict(str, gpu_percent=gpu_percent, vram_percent=vram_percent))
    return (checkData(gpuDat, data))
```

### Problems:
- Always read GPU index 0, which for many users is an integrated Intel/AMD iGPU sitting at 0%
- No native support for AMD or Intel discrete GPUs on Windows (no WMI fallback)
- No way to select a different GPU from the UI

## What Changed:

### Multi-vendor GPU detection at startup

A ``_build_gpu_list()`` function now runs once at startup and detects all GPUs across three backends.

2. Per-GPU usage queries

A ``_query_gpu_util(entry)`` function returns ``(gpu_percent, vram_percent)`` for any GPU entry.



### New ``gpuIndex`` config variable
A new ``gpuIndex`` setting (saved to config) controls which GPU is displayed:

Value | Meaning
-- | --
"0" | First detected GPU
"1" | Second detected GPU
"combined" | Average of all GPUs

### GPU selector in the UI (Behavior → GPU tab)
A dropdown combo box now lists all detected GPUs by name:

```py
_gpu_options = [_gpu_index_to_display[str(_i)] for _i in range(_gpu_count)] + ['combined']
...
```

### VRAM display added
The ``{vram_percent}`` variable is now available in the GPU display template, sourced from actual VRAM used/total (not memory bus bandwidth).

### Config version bump
The config version is bumped to 1.5.72 to include ``gpuIndex`` in saved settings, with full backward compatibility for all older config versions. The version itself was not bumped to 1.5.72:

```py
#importantest variables :)

run = True
playMsg = True
version = "1.5.71"
```

## New Dependencies

Package | Platform | Purpose
-- | -- | --
``pynvml`` | All | NVIDIA GPU stats (already present)
``wmi`` | Windows only | AMD/Intel GPU stats via DXGI performance counters
``pythoncom`` | Windows only | COM initialisation for WMI on background threads

## Note
I don't have a multi GPU system and therefore can't test how acurate ``combined`` is. 
All the changes I made were optimized around AMD GPUs. If the compadability with NVIDIA GPUs is maintained needs to be tested, this should be the case though as all AMD logic uses wmi as a fallback.
