### PR TITLE
Fix crashes, parsing, VR flag; add msg toggle lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ please-do-not-delete.txt
 /dist/
 osc-chat-tools.spec
 OCT_debug_log.txt
+/__pycache__/


### PR DESCRIPTION
# Minor fixes and improvements.

## Possible fix for ``vr_handler``

Python uses ``=`` for assignment and ``==`` for comparison. The original code used ``==``, meaning ``isVR`` was never actually modified, the expressions evaluated silently and were discarded.

```py
# BEFORE (broken)
def vr_handler(unused_address, args):
    if args ==1:
        isVR == True   # this is a comparison, not an assignment — does nothing
    else:
        isVR == False  # same issue
```
```py
# AFTER (fixed)
def vr_handler(unused_address, args):
    global isVR
    if args == 1:
        isVR = True
    else:
        isVR = False
    # This was a comparison, not an assignment, which is probably why this didn't work.
```
This is a silent bug since it would raise no errors, the code just never has any effect.

## Duplicate ``mute`` Definition in ``msgGen``

```py
# BEFORE (redundant first definition)
def mute(data=0):
    return (checkData("Coming Soon", data))
def stt(data=0):
    return (checkData("Coming Soon", data))
def div(data=0):
    return (checkData(middleBar, data))
def mute(data=0):
    if isMute: 
        ...
```
```py
# AFTER (first definition removed, only the real one remains)
def stt(data=0):
    return (checkData("Coming Soon", data))
def div(data=0):
    return (checkData(middleBar, data))
def mute(data=0):
    if isMute:
        ...
```
I just removed this, this was not a bug, just lines of code that did nothing.

## Possible ``TypeError`` when VRChat is not running

Problem: After the loop that searches for the VRChat process, ``vrcPID`` is only set if VRChat is actually found. If VRChat isn't running, ``vrcPID`` remains ``None``, and the next line unconditionally passes it to ``psutil.Process()``, which raises a ``TypeError``.

```py
# BEFORE (crashes if VRChat isn't found)
for proc in psutil.process_iter():
    if not run:
        break
    if "VRChat.exe" in proc.name():
        vrcPID = proc.pid
        break
    time.sleep(.01)
playTimeDat = time.mktime(time.localtime(psutil.Process(vrcPID).create_time()))
# ^ TypeError: psutil.Process(None) raises an exception
```
```py
# AFTER (guarded)
for proc in psutil.process_iter():
    if not run:
        break
    if "VRChat.exe" in proc.name():
        vrcPID = proc.pid
        break
    time.sleep(.01)
if vrcPID is not None:
    playTimeDat = time.mktime(time.localtime(psutil.Process(vrcPID).create_time()))
# playTimeDat simply isn't updated if VRChat isn't running, which is safe
# because the playtime layout element already handles vrcPID == None gracefully
```
## Race Condition Spawning Multiple Threads

Problem: If ``msgPlayToggle`` was called in rapid succession (e.g., by holding a keybind), multiple ``runmsg`` threads could be spawned before ``playMsg`` had a chance to be set back, resulting in duplicate/overlapping message sending.

```py
# BEFORE (race condition)
def msgPlayToggle():
  global playMsg
  if playMsg:
      playMsg = False
      time.sleep(.5)
  else:
    playMsg = True  
    msgThread = Thread(target=runmsg)
    msgThread.start()
    time.sleep(.5) 
```
```py
# AFTER (protected by a Lock)
_toggle_lock = Lock()

def msgPlayToggle():
    global playMsg
    with _toggle_lock:      # only one thread can execute this block at a time
        if playMsg:
            playMsg = False
            time.sleep(.5)
        else:
            playMsg = True
            msgThread = Thread(target=runmsg)
            msgThread.start()
            time.sleep(.5)
```
The ``Lock`` ensures that if a second call arrives while the first is still inside the with block, it waits rather than proceeding concurrently.

## Unhandled Parse Exception + Empty String Slice Bug

``ast.literal_eva`` on a malformed layout string raises an unhandled exception that would silently crash the event loop. 

```py
# BEFORE (crashes on malformed layout string)
      def layoutStorageAdd(a):
        if len(ast.literal_eval("["+window['layoutStorage'].get().replace("{", "\"").replace("}", "\",")[:-1]+"]")) < 15:
          window['layoutStorage'].update(value=values['layoutStorage']+" {"+a+"}")
        # ^ uses values['layoutStorage'] instead of the locally read value
        else:
          sg.popup("You have reached the limit of objects in the layout.\nYou can still add more in the manual edit section,\nhowever the UI will not reflect it")
```
```py
# AFTER (safe)
      def layoutStorageAdd(a):
        try:
          current = window['layoutStorage'].get()
          parsed = ast.literal_eval("["+current.replace("{", "\"").replace("}", "\",")[:-1]+"]") if current.strip() else []
          if len(parsed) < 15:
            window['layoutStorage'].update(value=current+" {"+a+"}")
          else:
            sg.popup("You have reached the limit of objects in the layout.\nYou can still add more in the manual edit section,\nhowever the UI will not reflect it")
        except Exception as e:
          sg.popup("Layout parse error: "+str(e))
```

## ``ValueError`` / ``TypeError``  on Non-Numeric Heart Rate

I don't know if this is an actual issue but:
If the value received is empty, None, or an unexpected format, calling ``int(heartRate)`` raises a ``ValueError`` or ``TypeError``, crashing the ``blinkHR`` thread entirely, which means the heart rate beat animation would stop working for the rest of the session.

```py
# BEFORE (crashes if heartRate is None, "", or non-numeric)
if heartRate == '':
    heartRate = 0
else:
    if int(heartRate) <= 0:    # TypeError if heartRate is None
        heartRate = 1
    if 60/int(heartRate) > 5:
        time.sleep(1)
    else:
        time.sleep(60/int(heartRate))
```
```py
# AFTER (safe conversion with fallback)
try:
try:
    hr_val = int(heartRate) if heartRate else 0
except (ValueError, TypeError):
    hr_val = 0
if hr_val <= 0:
    heartRate = 1
    hr_val = 1
if 60 / hr_val > 5:
    time.sleep(1)
else:
    time.sleep(60 / hr_val)
```
The ``try/except`` catches any bad value and falls back to ``0``, which is then clamped to ``1`` to avoid a division-by-zero. The BPM-to-sleep-duration logic is otherwise identical.